### PR TITLE
Add timestamp in deploy log url

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,8 +25,9 @@ gcloud container clusters get-credentials "$INPUT_CLUSTER" --zone "$INPUT_ZONE" 
 export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
-timestamp=$(date -d@"$(( `date +%s`+60))" '+%FT%T')
-log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;cursorTimestamp=$timestamp.2Z?project=$INPUT_PROJECT"
+timestamp1=$(date '+%FT%T')
+timestamp2=$(date -d@"$(( `date +%s`+20))" '+%FT%T')
+log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;timeRange=$timestamp1.2Z%2F$timestamp2.2?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ gcloud container clusters get-credentials "$INPUT_CLUSTER" --zone "$INPUT_ZONE" 
 export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
-timestamp=$(date -d@"$(( `date +%s`+60))" '+%FT%T.3Z')
+timestamp=$(date -d@"$(( `date +%s`+300))" '+%FT%T.3Z')
 log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;cursorTimestamp=$timestamp?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,8 +26,10 @@ export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
 timestamp1=$(date '+%FT%T')
-timestamp2=$(date -d@"$(( `date +%s`+20))" '+%FT%T')
-log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;timeRange=$timestamp1.2Z%2F$timestamp2.2?project=$INPUT_PROJECT"
+timestamp2=$(date -d@"$(( `date +%s`+200))" '+%FT%T')
+timestamp3=$(date -d@"$(( `date +%s`+10))" '+%FT%T')
+
+log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;timeRange=$timestamp1.2Z%2F$timestamp2.2;cursorTimestamp=$timestamp3.2Z?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ gcloud container clusters get-credentials "$INPUT_CLUSTER" --zone "$INPUT_ZONE" 
 export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
-timestamp=`date -u "+%FT%T"`
+timestamp=$(date -d@"$(( `date +%s`+60))" '+%FT%T')
 log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;cursorTimestamp=$timestamp.2Z?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,7 @@ export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
 timestamp=`date -u "+%FT%T.%3Z"`
-log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%;cursorTimestamp=$timestamp?project=$INPUT_PROJECT"
+log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME;cursorTimestamp=$timestamp?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,8 +25,8 @@ gcloud container clusters get-credentials "$INPUT_CLUSTER" --zone "$INPUT_ZONE" 
 export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
-timestamp=`date -u "+%FT%T.%3Z"`
-log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME;cursorTimestamp=$timestamp?project=$INPUT_PROJECT"
+timestamp=`date -u "+%FT%T"`
+log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;cursorTimestamp=$timestamp.2Z?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,8 @@ gcloud container clusters get-credentials "$INPUT_CLUSTER" --zone "$INPUT_ZONE" 
 export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
-log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22?project=$INPUT_PROJECT"
+timestamp=`date -u "+%FT%T.%3Z"`
+log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%;cursorTimestamp=$timestamp?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,11 +25,8 @@ gcloud container clusters get-credentials "$INPUT_CLUSTER" --zone "$INPUT_ZONE" 
 export RELEASE_NAME=$(/applicationName.sh "$INPUT_HELM_ARGS")
 echo "Release name: $RELEASE_NAME"
 
-timestamp1=$(date '+%FT%T')
-timestamp2=$(date -d@"$(( `date +%s`+200))" '+%FT%T')
-timestamp3=$(date -d@"$(( `date +%s`+10))" '+%FT%T')
-
-log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;timeRange=$timestamp1.2Z%2F$timestamp2.2;cursorTimestamp=$timestamp3.2Z?project=$INPUT_PROJECT"
+timestamp=$(date -d@"$(( `date +%s`+60))" '+%FT%T.3Z')
+log_url="https://console.cloud.google.com/logs/query;query=resource.labels.project_id%3D%22$INPUT_PROJECT%22%0Aresource.labels.location%3D%22$INPUT_ZONE%22%0Aresource.labels.cluster_name%3D%22$INPUT_CLUSTER%22%0A%22$RELEASE_NAME%22;cursorTimestamp=$timestamp?project=$INPUT_PROJECT"
 echo "GCP logs:  $log_url"
 echo "::set-output name=log_url::$log_url"
 


### PR DESCRIPTION
Will att cursorTimestamp (+300s) in gcp log url so you get logs when the service have been deploy and not current time if you are looking at an old deploy for etc troubleshooting